### PR TITLE
Fix cargo fmt job's manifest path handling

### DIFF
--- a/.github/workflows/ci_baseline_rust_lints.yml
+++ b/.github/workflows/ci_baseline_rust_lints.yml
@@ -48,7 +48,8 @@ jobs:
           toolchain: ${{inputs.rust_toolchain}}
       - name: "cargo fmt"
         id: fmt
-        run: "cargo fmt --manifest-path $CARGO_MANIFEST_DIR/Cargo.toml -v -- --check"
+        run: "cargo fmt -v -- -v --check"
+        working-directory: ${{inputs.manifest_dir}}
 
   cargo_clippy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It's easier to just use working-directory, tbh.