### PR TITLE
Use problem matchers to highlight compilation/lint/formatting issues

### DIFF
--- a/.github/workflows/_internal_expected_lint_failure.yml
+++ b/.github/workflows/_internal_expected_lint_failure.yml
@@ -16,9 +16,6 @@ on:
         required: false
         type: string
         default: stable
-      cargo_clippy_args:
-        description: "Arguments to pass to `cargo clippy` in the test step"
-        type: string
 
 jobs:
   lints:
@@ -26,7 +23,6 @@ jobs:
     with:
       manifest_dir: ${{inputs.manifest_dir}}
       rust_toolchain: ${{inputs.rust_toolchain}}
-      cargo_clippy_args: ${{inputs.cargo_clippy_args}}
       _internal_continue_on_error: true
 
   expect_expected_failure:

--- a/.github/workflows/ci_baseline_rust_lints.yml
+++ b/.github/workflows/ci_baseline_rust_lints.yml
@@ -38,6 +38,8 @@ jobs:
   cargo_fmt:
     runs-on: ubuntu-latest
     continue-on-error: ${{inputs._internal_continue_on_error}}
+    env:
+      CARGO_TERM_COLOR: "never"
     outputs:
       result: ${{steps.fmt.outcome}}
     steps:
@@ -46,6 +48,7 @@ jobs:
         with:
           components: rustfmt
           toolchain: ${{inputs.rust_toolchain}}
+      - uses: r7kamura/rust-problem-matchers@v1
       - name: "cargo fmt"
         id: fmt
         run: "cargo fmt -v -- -v --check"
@@ -54,6 +57,8 @@ jobs:
   cargo_clippy:
     runs-on: ubuntu-latest
     continue-on-error: ${{inputs._internal_continue_on_error}}
+    env:
+      CARGO_TERM_COLOR: "never"
     outputs:
       result: ${{steps.clippy.outcome}}
     steps:
@@ -62,14 +67,8 @@ jobs:
         with:
           components: clippy
           toolchain: ${{inputs.rust_toolchain}}
-      - uses: giraffate/clippy-action@v1
-        id: clippy
-        with:
-          workdir: ${{inputs.manifest_dir}}
-          reporter: "github-check"
-          filter_mode: nofilter
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          clippy_flags: ${{inputs.cargo_clippy_args}}
+      - uses: r7kamura/rust-problem-matchers@v1
+      - run: cargo +${{inputs.rust_toolchain}} clippy ${{inputs.cargo_clippy_args}}
 
   cargo_deny:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_baseline_rust_lints.yml
+++ b/.github/workflows/ci_baseline_rust_lints.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           components: clippy
           toolchain: ${{inputs.rust_toolchain}}
-      - uses: r7kamura/rust-problem-matchers@v1
+      - uses: antifuchs/rust-problem-matchers@clippy-regex
       - run: cargo +${{inputs.rust_toolchain}} clippy ${{inputs.cargo_clippy_args}}
         working-directory: ${{inputs.manifest_dir}}
 

--- a/.github/workflows/ci_baseline_rust_lints.yml
+++ b/.github/workflows/ci_baseline_rust_lints.yml
@@ -36,6 +36,7 @@ env:
 
 jobs:
   cargo_fmt:
+    name: cargo fmt ${{inputs.manifest_dir}}
     runs-on: ubuntu-latest
     continue-on-error: ${{inputs._internal_continue_on_error}}
     env:
@@ -55,6 +56,7 @@ jobs:
         working-directory: ${{inputs.manifest_dir}}
 
   cargo_clippy:
+    name: cargo clippy ${{inputs.manifest_dir}}
     runs-on: ubuntu-latest
     continue-on-error: ${{inputs._internal_continue_on_error}}
     env:
@@ -72,6 +74,7 @@ jobs:
         working-directory: ${{inputs.manifest_dir}}
 
   cargo_deny:
+    name: cargo deny ${{inputs.manifest_dir}}
     runs-on: ubuntu-latest
     continue-on-error: ${{inputs._internal_continue_on_error}}
     outputs:

--- a/.github/workflows/ci_baseline_rust_lints.yml
+++ b/.github/workflows/ci_baseline_rust_lints.yml
@@ -69,6 +69,7 @@ jobs:
           toolchain: ${{inputs.rust_toolchain}}
       - uses: r7kamura/rust-problem-matchers@v1
       - run: cargo +${{inputs.rust_toolchain}} clippy ${{inputs.cargo_clippy_args}}
+        working-directory: ${{inputs.manifest_dir}}
 
   cargo_deny:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_baseline_rust_tests.yml
+++ b/.github/workflows/ci_baseline_rust_tests.yml
@@ -28,6 +28,8 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     continue-on-error: ${{inputs._internal_continue_on_error}}
+    env:
+      CARGO_TERM_COLOR: "never"
     outputs:
       result: ${{steps.test.outcome}}
     steps:
@@ -35,6 +37,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{inputs.rust_toolchain}}
+      - uses: r7kamura/rust-problem-matchers@v1
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest


### PR DESCRIPTION
This requires disabling terminal colors, but ehhh, seems fine.

Fixes #6.